### PR TITLE
Removed superflous empty threads constructed during simulation

### DIFF
--- a/src/runDMC.cpp
+++ b/src/runDMC.cpp
@@ -30,7 +30,7 @@ void run_dmc_sim(Prms &p,
     rsim["eq4"] = eq4;
     
     // run comp and incomp simulation 
-    std::vector<std::thread> threads(2);
+    std::vector<std::thread> threads;
     std::vector<std::string> compatibility{"comp", "incomp"};
     std::vector<int> sign{1, -1};
     


### PR DESCRIPTION
fixes #1

Removes the two superflous threads created during simulation.

Constructing these threads may waste resources, thus slowing down simulation.